### PR TITLE
:bug: Fix setup & collapse profiles

### DIFF
--- a/extensions/commands/cmd_hal.py
+++ b/extensions/commands/cmd_hal.py
@@ -63,18 +63,16 @@ def hal_setup(conan_api: ConanAPI, parser, subparser, *args):
         logger.error(f"❌ Failed to configure remote: {e}")
         return
 
-    profile_api = ProfilesAPI(conan_api)
-
     try:
         # If this succeeds then there is nothing to do. If it fails, then we
         # should create a default host profile for the user.
-        profile_api.get_default_host()
+        conan_api.profiles.get_default_host()
         logger.info("✅ System already has a default host profile, proceeding!")
     except ConanException:
         logger.info("❌ Default host profile NOT found! Generating one now!")
-        HOME_PATH = Path(ConfigAPI(conan_api).home())
+        HOME_PATH = Path(conan_api.home_folder)
         DEFAULT_PROFILE_PATH = HOME_PATH / "profiles" / "default"
-        DETECTED_PROFILE_INFO = profile_api.detect()
+        DETECTED_PROFILE_INFO = conan_api.profiles.detect()
         DEFAULT_PROFILE_PATH.write_text(str(DETECTED_PROFILE_INFO))
         logger.info("✅ Default profile generated!")
         logger.debug(f"🔍 Profile Contents:\n{DETECTED_PROFILE_INFO}")

--- a/profiles/hal/tc/arm-gcc-12.2
+++ b/profiles/hal/tc/arm-gcc-12.2
@@ -1,8 +1,0 @@
-[settings]
-compiler=gcc
-compiler.cppstd=23
-compiler.libcxx=libstdc++11
-compiler.version=12.2
-
-[tool_requires]
-arm-gnu-toolchain/12.2

--- a/profiles/hal/tc/arm-gcc-13
+++ b/profiles/hal/tc/arm-gcc-13
@@ -2,7 +2,7 @@
 compiler=gcc
 compiler.cppstd=23
 compiler.libcxx=libstdc++11
-compiler.version=11.3
+compiler.version=13
 
 [tool_requires]
-arm-gnu-toolchain/11.3
+arm-gnu-toolchain/13.3

--- a/profiles/hal/tc/arm-gcc-13.2
+++ b/profiles/hal/tc/arm-gcc-13.2
@@ -1,8 +1,0 @@
-[settings]
-compiler=gcc
-compiler.cppstd=23
-compiler.libcxx=libstdc++11
-compiler.version=13.2
-
-[tool_requires]
-arm-gnu-toolchain/13.2

--- a/profiles/hal/tc/arm-gcc-13.3
+++ b/profiles/hal/tc/arm-gcc-13.3
@@ -1,8 +1,0 @@
-[settings]
-compiler=gcc
-compiler.cppstd=23
-compiler.libcxx=libstdc++11
-compiler.version=13.3
-
-[tool_requires]
-arm-gnu-toolchain/13.3

--- a/profiles/hal/tc/arm-gcc-14
+++ b/profiles/hal/tc/arm-gcc-14
@@ -5,4 +5,4 @@ compiler.libcxx=libstdc++11
 compiler.version=14
 
 [tool_requires]
-arm-gnu-toolchain/[>=14.0 <15]
+arm-gnu-toolchain/14.3

--- a/profiles/hal/tc/arm-gcc-14.3
+++ b/profiles/hal/tc/arm-gcc-14.3
@@ -1,8 +1,0 @@
-[settings]
-compiler=gcc
-compiler.cppstd=23
-compiler.libcxx=libstdc++11
-compiler.version=14.3
-
-[tool_requires]
-arm-gnu-toolchain/14.3

--- a/profiles/hal/tc/llvm-19
+++ b/profiles/hal/tc/llvm-19
@@ -1,8 +1,0 @@
-[settings]
-compiler=clang
-compiler.cppstd=23
-compiler.libcxx=libc++
-compiler.version=19
-
-[tool_requires]
-llvm-toolchain/[>=19.0.0 <20.0.0]

--- a/profiles/hal/tc/llvm-19.1.5
+++ b/profiles/hal/tc/llvm-19.1.5
@@ -1,8 +1,0 @@
-[settings]
-compiler=clang
-compiler.cppstd=23
-compiler.libcxx=libc++
-compiler.version=19
-
-[tool_requires]
-llvm-toolchain/19.1.5

--- a/profiles/hal/tc/llvm-19.1.7
+++ b/profiles/hal/tc/llvm-19.1.7
@@ -1,8 +1,0 @@
-[settings]
-compiler=clang
-compiler.cppstd=23
-compiler.libcxx=libc++
-compiler.version=19
-
-[tool_requires]
-llvm-toolchain/19.1.7

--- a/profiles/hal/tc/llvm-20
+++ b/profiles/hal/tc/llvm-20
@@ -5,4 +5,4 @@ compiler.libcxx=libc++
 compiler.version=20
 
 [tool_requires]
-llvm-toolchain/[>=20.0.0 <21.0.0]
+llvm-toolchain/20

--- a/profiles/hal/tc/llvm-20.1.8
+++ b/profiles/hal/tc/llvm-20.1.8
@@ -1,8 +1,0 @@
-[settings]
-compiler=clang
-compiler.cppstd=23
-compiler.libcxx=libc++
-compiler.version=20
-
-[tool_requires]
-llvm-toolchain/20.1.8


### PR DESCRIPTION
The profiles object should come from the `conan_api` parameter. The ProfileAPI class should not be constructed on its own.

Collapsing profiles down to the major versions except for the few that are still in use by clients, namely `arm-gcc-12.3` and `arm-gcc-14.2`.