### PR TITLE
:technologist: Add cmake & ninja to all llvm profiles

### DIFF
--- a/profiles/hal/tc/llvm-20
+++ b/profiles/hal/tc/llvm-20
@@ -6,3 +6,8 @@ compiler.version=20
 
 [tool_requires]
 llvm-toolchain/20
+cmake/[>=3.28.0 <5.0.0]
+ninja/[^1.0.0]
+
+[conf]
+tools.cmake.cmaketoolchain:generator=Ninja


### PR DESCRIPTION
This allows applications and libraries to automatically pull in cmake and ninja for building their applications.